### PR TITLE
Resolve ansible-lint Check Failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Example Playbook
     - hosts: servers
       roles:
         - {
-          role: disable-thp,
+          role: disable_thp,
           disable_thp_before_service: 'mongod'
         }
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,4 +16,6 @@ galaxy_info:
     - ubuntu
     - thp
 
+  role_name: disable_thp
+
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,6 @@ galaxy_info:
 
   galaxy_tags:
     - ubuntu
-    - disable-thp
+    - thp
 
 dependencies: []


### PR DESCRIPTION
We use this as a dependency in one of our projects (https://github.com/cisagov/ansible-role-mongo), and when trying to perform testing with [`molecule`](https://github.com/ansible-community/molecule) it fails checks by [`ansible-lint`](https://github.com/ansible/ansible-lint). This PR resolves the two fatal warnings shown when running `ansible-lint` as seen below:

```console
$ ansible-lint .
WARNING  Listing 2 violation(s) that are fatal
[702] Tags must contain lowercase letters and digits only, invalid: 'disable-thp'
meta/main.yml:1
{'meta/main.yml': {'galaxy_info': {'author': 'David Pujadas', 'description': 'Ansible role to disable Transparent Hugepages on Ubuntu server', 'license': 'MIT', 'min_ansible_version': 2.2, 'platforms': [{'name': 'Ubuntu', 'versions': ['trusty', 'xenial'], '__line__': 10, '__file__': 'ansible-role-disable-thp/meta/main.yml'}], 'galaxy_tags': ['ubuntu', 'disable-thp'], '__line__': 1, '__file__': ansible-role-disable-thp/meta/main.yml'}, 'dependencies': [], '__line__': 1, '__file__': 'ansible-role-disable-thp/meta/main.yml', 'skipped_rules': []}}

[106] Role name disable-thp does not match ``^[a-z][a-z0-9_]+$`` pattern
tasks/systemd.yml:1
- name: Ensure disable-thp is {{ disable_thp_state }} and enabled at boot

You can skip specific rules or tags by adding them to your configuration file:

┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ # .ansible-lint                                                                                                      │
│ warn_list:  # or 'skip_list' to silence them completely                                                              │
│   - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern                                               │
│   - '702'  # Tags must contain lowercase letters and digits only                                                     │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```